### PR TITLE
add the ability to take notes during game

### DIFF
--- a/src/Game.module.css
+++ b/src/Game.module.css
@@ -263,3 +263,42 @@ button.token:active:not(:disabled) {
         color: rgba(0, 0, 0, 0.3);
     }
 }
+
+.notesSection {
+    margin: 16px 0;
+    padding: 16px;
+    background-color: rgba(255, 255, 255, 0.05);
+    border-radius: 8px;
+}
+
+.notesSection h3 {
+    margin-top: 0;
+}
+
+.playerNotes {
+    margin-bottom: 16px;
+}
+
+.playerNotes h4 {
+    margin: 8px 0 4px 0;
+    font-size: 16px;
+}
+
+.noteEntry {
+    display: flex;
+    gap: 8px;
+    margin: 4px 0;
+    padding: 4px 8px;
+    background-color: rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+}
+
+.noteToken {
+    font-weight: bold;
+    color: #aaa;
+    min-width: 140px;
+}
+
+.noteText {
+    color: #fff;
+}

--- a/src/NoteModal.module.css
+++ b/src/NoteModal.module.css
@@ -1,0 +1,48 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.panel {
+    background-color: #2a2a2a;
+    padding: 24px;
+    border-radius: 8px;
+    min-width: 400px;
+    max-width: 600px;
+}
+
+.panel h2 {
+    margin-top: 0;
+}
+
+.textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px;
+    font-family: inherit;
+    font-size: 14px;
+    border-radius: 4px;
+    border: 1px solid #555;
+    background-color: #1a1a1a;
+    color: white;
+    resize: vertical;
+    margin: 12px 0;
+}
+
+.buttons {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.buttons button {
+    padding: 8px 16px;
+}

--- a/src/NoteModal.tsx
+++ b/src/NoteModal.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import * as styles from "./NoteModal.module.css";
+
+type NoteModalProps = {
+    round: number;
+    playerName: string;
+    currentNote: string;
+    onSave: (note: string) => void;
+    onClose: () => void;
+};
+
+export function NoteModal(props: NoteModalProps) {
+    const { round, playerName, currentNote, onSave, onClose } = props;
+    const [noteText, setNoteText] = useState(currentNote);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                onClose();
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [onClose]);
+
+    const handleSave = () => {
+        onSave(noteText);
+        onClose();
+    };
+
+    return (
+        <div className={styles.overlay} onClick={onClose}>
+            <div className={styles.panel} onClick={(e) => e.stopPropagation()}>
+                <h2>Note about {playerName}</h2>
+                <p>Round {round + 1}</p>
+                <textarea
+                    className={styles.textarea}
+                    value={noteText}
+                    onChange={(e) => setNoteText(e.target.value)}
+                    placeholder="Add your note here..."
+                    rows={5}
+                    autoFocus
+                />
+                <div className={styles.buttons}>
+                    <button onClick={handleSave}>Save</button>
+                    <button onClick={onClose}>Cancel</button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/TokenV.tsx
+++ b/src/TokenV.tsx
@@ -20,11 +20,13 @@ export type TokenProps = {
     disabled?: boolean;
     past?: boolean;
     onClick?: () => void;
+    onContextMenu?: (e: React.MouseEvent) => void;
+    title?: string;
 };
 export const TOKEN_STYLES = [styles.token1, styles.token2, styles.token3, styles.token4];
 // how 2 naming?
 export function TokenV(props: TokenProps) {
-    const { token, disabled, past, onClick } = props;
+    const { token, disabled, past, onClick, onContextMenu, title } = props;
     const animatorContext = useContext(TokenAnimatorContext);
     const containerRef = useRef<HTMLDivElement>(null);
     const ref = useRef<HTMLButtonElement>(null);
@@ -60,12 +62,13 @@ export function TokenV(props: TokenProps) {
         return () => observer.disconnect();
     }, [token, animatorContext]);
     return (
-        <div className={styles.noToken} ref={containerRef}>
+        <div className={styles.noToken} ref={containerRef} onContextMenu={onContextMenu}>
             {token && (
                 <button
                     className={`${styles.token} ${past ? styles.pastToken : ""} ${TOKEN_STYLES[token.round]}`}
                     disabled={disabled}
                     onClick={onClick}
+                    title={title}
                     ref={ref}
                 >
                     {token.index}

--- a/src/gameImpl.ts
+++ b/src/gameImpl.ts
@@ -100,6 +100,7 @@ export function advanceRound(game: Immutable<BiddingStateWithoutJokers>): Immuta
             winRecord: game.winRecord,
             pastRounds: game.pastRounds,
             revealIndex: 1,
+            notes: game.notes,
         };
     }
     draft.pastRounds.push(currentRound);

--- a/src/gameState.ts
+++ b/src/gameState.ts
@@ -86,6 +86,7 @@ export interface BiddingState<PlayerCard = DeckCard | DeckCard[]> extends BaseSt
     pastRounds: Round[];
     futureRounds: Round[];
     log: RoundLogEntry[][];
+    notes?: Record<string, Record<string, string>>;
 }
 export type BiddingStateWithoutJokers = BiddingState<PokerCard>;
 
@@ -94,6 +95,7 @@ export interface ScoringState extends BaseStartedState<PokerCard> {
     log: RoundLogEntry[][];
     revealIndex: number; // 1-indexed
     pastRounds: Round[];
+    notes?: Record<string, Record<string, string>>;
 }
 
 export type StartedState = BiddingState | ScoringState;


### PR DESCRIPTION
- right-click on a player's chip position to take notes for that player on that turn
- hover a player's previous turn to see your notes on that turn
- all notes are shared publicly at the end of the round